### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-build-and-test.yml
+++ b/.github/workflows/gradle-build-and-test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDLib/security/code-scanning/5](https://github.com/XDPXI/XDLib/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimum permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout@v4` action requires `contents: read` to fetch the repository code.
- The `actions/upload-artifact@v4` action does not require additional permissions beyond `contents: read`.

Thus, we will set `permissions: contents: read` at the root level of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
