### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDLib/security/code-scanning/4](https://github.com/XDPXI/XDLib/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since this workflow only validates the Gradle wrapper, it likely only needs `contents: read` permission to access the repository's files. This change will ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
